### PR TITLE
Adding option to charge only when the device is plugged in

### DIFF
--- a/app/src/main/java/me/phh/treble/app/Duo.kt
+++ b/app/src/main/java/me/phh/treble/app/Duo.kt
@@ -5,17 +5,23 @@ import android.content.SharedPreferences
 import android.preference.PreferenceManager
 import android.util.Log
 import android.content.Intent
+import android.content.IntentFilter
 import java.io.File
 import java.lang.Exception
 import me.phh.treble.app.MSPenCharger
+import me.phh.treble.app.WirelessPenChargerBroadcastReceiver
 import android.os.ServiceManager
 import android.os.RemoteException
 import android.os.SystemProperties
 import androidx.preference.SwitchPreference
+import android.os.BatteryManager;
 
 object Duo: EntryStartup {
     var ctxt: Context? = null
     private var isDuo2: Boolean = false
+    private var penChargerBroadcastReceiver: WirelessPenChargerBroadcastReceiver? = null
+    private var penChargerIntentFilter: IntentFilter? = null
+
     val spListener = SharedPreferences.OnSharedPreferenceChangeListener { sp, key ->
         when(key) {
             DuoSettings.disableHingeGap -> {
@@ -54,6 +60,8 @@ object Duo: EntryStartup {
             DuoSettings.wirelessPenCharging -> {
                 // Retrieve the boolean value from shared preferences
                 val b = sp.getBoolean(key, false)
+                val value = if(b) "1" else "0"
+                Misc.safeSetprop("persist.sys.phh.duo.pen_charger_enabled", value)
                 // val readvalue = MSPenCharger.readPenCharger()
                 // Log.e("PHH", "Current value in the ms_pen_charger file (current value: $readvalue)")
                 if (isDuo2) {  
@@ -77,7 +85,58 @@ object Duo: EntryStartup {
                     }                   
                 }
             }
+
+            DuoSettings.chargePenOnlyWhenDeviceIsCharging -> {
+                val b = sp.getBoolean(key, false)
+                val value = if(b) "1" else "0"
+                Misc.safeSetprop("persist.sys.phh.duo.charge_pen_when_device_charging", value)
+                if (isDuo2) {  
+                    when (b) {
+                        true -> {
+                            //Check current state.
+                            setupBroadcastListener()
+                            if(isDeviceCharging()){
+                                MSPenCharger.turnOnPenCharger()
+                            }
+                            else{
+                                MSPenCharger.turnOffPenCharger()
+                            }
+                        }
+                        false -> {
+                            destroyBroadcastListener()
+                        }
+                    }                   
+                }
+            }
         }
+    }
+
+    private fun setupBroadcastListener() {
+        //Unregister if there are still some dangling loose ends to handle.
+        if(penChargerBroadcastReceiver != null){
+            this.ctxt?.unregisterReceiver(penChargerBroadcastReceiver)
+        }
+
+        // create broadcast receiver.
+        penChargerBroadcastReceiver = WirelessPenChargerBroadcastReceiver()
+
+        // On power change, the broadcast receiver should act.
+        penChargerIntentFilter = IntentFilter().also{ intentFilter -> 
+            intentFilter.addAction("ACTION_POWER_CONNECTED")
+            intentFilter.addAction("ACTION_POWER_DISCONNECTED")
+            this.ctxt?.registerReceiver(penChargerBroadcastReceiver, intentFilter)
+        }
+    }
+
+    private fun destroyBroadcastListener(){
+        penChargerBroadcastReceiver?.let{
+            this.ctxt?.unregisterReceiver(it)
+        }
+    }
+
+    private fun isDeviceCharging() : Boolean {
+        var batteryManager : BatteryManager = ctxt?.getSystemService(Context.BATTERY_SERVICE) as BatteryManager
+        return batteryManager.isCharging();
     }
 
     override fun startup(ctxt: Context) {
@@ -92,5 +151,29 @@ object Duo: EntryStartup {
         }
 
         this.ctxt = ctxt.applicationContext
+
+        //Read the current duo preferences and act on it.
+        if(isDuo2){
+            val chargeWhenPluggedIn : Boolean = SystemProperties.get("persist.sys.phh.duo.charge_pen_when_device_charging", "0") == "1"
+            val penChargerEnabled : Boolean = SystemProperties.get("persist.sys.phh.duo.pen_charger_enabled", "0") == "1"
+            // The device just started, the broadcast receiver is not setup, set it up if enabled.
+            if(chargeWhenPluggedIn){
+                setupBroadcastListener()
+
+                if(isDeviceCharging()){
+                    MSPenCharger.turnOnPenCharger()
+                }
+            }
+
+            //Only turn the pen charger on if explictly enabled, and the plug-in option is disabled.
+            if(penChargerEnabled && !chargeWhenPluggedIn){
+                MSPenCharger.turnOnPenCharger()
+            }
+
+            //In case for users that have the device default set to ON, but have left the option off.
+            if(!penChargerEnabled && !chargeWhenPluggedIn){
+                MSPenCharger.turnOffPenCharger()
+            }
+        }
     }
 }

--- a/app/src/main/java/me/phh/treble/app/Duo.kt
+++ b/app/src/main/java/me/phh/treble/app/Duo.kt
@@ -95,6 +95,8 @@ object Duo: EntryStartup {
                         true -> {
                             //Check current state.
                             setupBroadcastListener()
+
+                            //Do an initial check.
                             if(isDeviceCharging()){
                                 MSPenCharger.turnOnPenCharger()
                             }
@@ -104,6 +106,14 @@ object Duo: EntryStartup {
                         }
                         false -> {
                             destroyBroadcastListener()
+
+                            //Handle change if the pen charger is enabled.
+                            if(SystemProperties.get("persist.sys.phh.duo.pen_charger_enabled", "0") == "1"){
+                                MSPenCharger.turnOnPenCharger()
+                            }
+                            else{
+                                MSPenCharger.turnOffPenCharger()
+                            }
                         }
                     }                   
                 }
@@ -113,8 +123,12 @@ object Duo: EntryStartup {
 
     private fun setupBroadcastListener() {
         //Unregister if there are still some dangling loose ends to handle.
-        if(penChargerBroadcastReceiver != null){
-            this.ctxt?.unregisterReceiver(penChargerBroadcastReceiver)
+        try{
+            if(penChargerBroadcastReceiver != null){
+                this.ctxt?.unregisterReceiver(penChargerBroadcastReceiver)
+            }
+        } catch (e: IllegalArgumentException){
+            // Do nothing. the register is already unregistered it seems.
         }
 
         // create broadcast receiver.
@@ -129,9 +143,14 @@ object Duo: EntryStartup {
     }
 
     private fun destroyBroadcastListener(){
-        penChargerBroadcastReceiver?.let{
-            this.ctxt?.unregisterReceiver(it)
+        try{
+            penChargerBroadcastReceiver?.let{
+                this.ctxt?.unregisterReceiver(it)
+            }
+        } catch (e: IllegalArgumentException){
+            // Do nothing. the register is already unregistered it seems.
         }
+
     }
 
     private fun isDeviceCharging() : Boolean {
@@ -162,6 +181,9 @@ object Duo: EntryStartup {
 
                 if(isDeviceCharging()){
                     MSPenCharger.turnOnPenCharger()
+                }
+                else{
+                    MSPenCharger.turnOffPenCharger()
                 }
             }
 

--- a/app/src/main/java/me/phh/treble/app/DuoSettings.kt
+++ b/app/src/main/java/me/phh/treble/app/DuoSettings.kt
@@ -10,6 +10,7 @@ object DuoSettings : Settings {
     val disableHingeGap = "key_disable_hinge_gap"
     val lockSingleScreenPosture = "key_duo_posture_lock"
     val wirelessPenCharging = "wireless_pen_charging"
+    val chargePenOnlyWhenDeviceIsCharging = "charge_pen_while_device_is_charging"
 
     override fun enabled() = (SystemProperties.get("ro.hardware", "N/A") == "surfaceduo" || SystemProperties.get("ro.hardware", "N/A") == "surfaceduo2")
 }
@@ -28,6 +29,12 @@ class DuoSettingsFragment : SettingsFragment() {
             wirelessPenChargingPref?.let {
                 preferenceScreen.removePreference(it)
                 Log.d("PHH", "Wireless Pen Charging preference removed for hardware: $hardware")
+            }
+
+            val chargePenOnlyWhenDeviceIsChargingPreference: SwitchPreference? = findPreference(DuoSettings.chargePenOnlyWhenDeviceIsCharging)
+            chargePenOnlyWhenDeviceIsChargingPreference?.let {
+                preferenceScreen.removePreference(it)
+                Log.d("PHH", "Wireless Pen Charger during device charge preference removed for hardware: $hardware")
             }
         }
     }

--- a/app/src/main/java/me/phh/treble/app/MSPenCharger.kt
+++ b/app/src/main/java/me/phh/treble/app/MSPenCharger.kt
@@ -1,6 +1,11 @@
 package me.phh.treble.app
 
 import android.service.quicksettings.TileService
+import android.content.BroadcastReceiver
+import android.content.Intent
+import android.content.Context
+import android.os.SystemProperties
+import android.util.Log
 
 object MSPenCharger {
     init {
@@ -42,3 +47,38 @@ class MsPENTileService: TileService() {
       super.onTileRemoved()
     }
   }
+
+
+// This should only work when the broadcast receiver is registered
+// and ready to change the power state of the pen charger.
+public class WirelessPenChargerBroadcastReceiver: BroadcastReceiver() {
+  private var isDuo2: Boolean = false
+
+  companion object {
+    const val TAG = "WIRELESS PEN CHARGER"
+  }
+
+  override fun onReceive(context: Context, intent: Intent){
+    val action: String? = intent.getAction()
+    isDuo2 = SystemProperties.get("ro.hardware", "N/A") == "surfaceduo2"
+
+    //exit early if duo 1 is here
+    if(!isDuo2){
+      Log.d(TAG, "Exiting as this device is not a duo 2")
+      return
+    }
+    
+    when(action){
+      "ACTION_POWER_CONNECTED" -> {
+        // Turn power on.
+        MSPenCharger.turnOnPenCharger()
+        Log.d(TAG, "Pen Charger turned on from plugged in event.")
+      }
+      "ACTION_POWER_DISCONNECTED" -> {
+        // Shut power off.
+        MSPenCharger.turnOffPenCharger()
+        Log.d(TAG, "Pen Charger turned off from unplugged event.")
+      }
+    }
+  }
+}

--- a/app/src/main/res/xml/pref_duo.xml
+++ b/app/src/main/res/xml/pref_duo.xml
@@ -18,4 +18,10 @@
         android:title="Enable Surface Slim Pen Wireless Charging"
         android:summary="Allows pen charging when pen case is attached. May drain more battery."
     />
+    <SwitchPreference
+        android:defaultValue="false"
+        android:key="charge_pen_while_device_is_charging"
+        android:title="Charge Pen only when device is plugged in."
+        android:summary="Only charges pen when the device is plugged in. When unplugged, the pen will stop charging. Overrides the previous option."
+    />
 </PreferenceScreen>

--- a/app/src/main/res/xml/pref_duo.xml
+++ b/app/src/main/res/xml/pref_duo.xml
@@ -21,7 +21,7 @@
     <SwitchPreference
         android:defaultValue="false"
         android:key="charge_pen_while_device_is_charging"
-        android:title="Charge Pen only when device is plugged in."
+        android:title="Charge Pen only when device is plugged in"
         android:summary="Only charges pen when the device is plugged in. When unplugged, the pen will stop charging. Overrides the previous option."
     />
 </PreferenceScreen>


### PR DESCRIPTION
#Adding option to charge only when the device is plugged in

- Adds option to charge the pen ONLY when the charger is attached.
- Adds a broadcast receiver that is removed/added on boot and on option change.
- Also checks if the pen needs to be turned on/off after booting, using preserved system properties.